### PR TITLE
Remove `unsafeFlags` from Package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,12 +28,6 @@ let package = Package(
             name: "XCTestExtension",
             dependencies: [
                 "Difference"
-            ],
-            swiftSettings: [
-                .unsafeFlags([
-                    "-Xfrontend",
-                    "-strict-concurrency=complete"
-                ])
             ]
         ),
         .testTarget(


### PR DESCRIPTION
Using `unsafeFlags` works only for local packages. SPM would not allow to build a remote package containing `unsafeFlags`.